### PR TITLE
fix/cant-trim-null

### DIFF
--- a/docs/App.vue
+++ b/docs/App.vue
@@ -3,7 +3,6 @@
     <AutoComplete
       :limit="5"
       :suggestions="suggestions"
-      @focus="onFocus"
       @selectionChange="onSelectionChange"
       ref="autocomplete"
       v-model="query"

--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -320,6 +320,7 @@ export default {
     suggestionsShouldShow() {
       return (
         this.isFocused &&
+        this.query &&
         this.query.trim().length > 0 &&
         this.suggestions.length > 0 &&
         !this.hideResults


### PR DESCRIPTION
- Properly checks for input before attempting to call `trim()`
- Removes dead code in docs app